### PR TITLE
1回目のinitial_stateからの遷移時のみ、unset_old_most_recentをスキップするように修正

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -72,7 +72,7 @@ module Statesman
 
         ::ActiveRecord::Base.transaction do
           @observer.execute(:before, from, to, transition)
-          unset_old_most_recent unless parent_model.state_machine.class.initial_state == from
+          unset_old_most_recent if parent_model.state_machine.class.initial_state != from || transitions_for_parent.exists?(most_recent: true)
           transition.save!
           @last_transition = transition
           @observer.execute(:after, from, to, transition)


### PR DESCRIPTION
## 原因
2周目以降のinitial_stateからの状態遷移で `unset_old_most_recent` が呼ばれないため、 `most_recent` が更新されずに `Statesman::TransitionConflictError: Mysql2::Error: Duplicate entry` が発生してしまう

## 対応
initial_stateからの状態遷移かつレコードがある場合は、 `unset_old_most_recent` を呼ぶために、レコードの存在チェックを追加した